### PR TITLE
Check ipfs path with is-ipfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "ipfs-blocks": "^0.1.0",
-    "is-ipfs": "github:nginnever/is-ipfs.git#0ca3ad3c10e4dfb549f0ca70824a9bb07ea6777b",
+    "is-ipfs": "^0.2.0",
     "multihashing": "^0.2.0",
     "protocol-buffers": "^3.1.4",
     "stable": "^0.1.5"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "url": "https://github.com/vijayee/js-ipfs-merkle-dag.git"
   },
   "dependencies": {
-    "bl": "^1.0.0",
     "ipfs-blocks": "^0.1.0",
+    "is-ipfs": "^0.1.0",
     "multihashing": "^0.2.0",
     "protocol-buffers": "^3.1.4",
     "stable": "^0.1.5"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "ipfs-blocks": "^0.1.0",
-    "is-ipfs": "^0.1.0",
+    "is-ipfs": "github:nginnever/is-ipfs.git#0ca3ad3c10e4dfb549f0ca70824a9bb07ea6777b",
     "multihashing": "^0.2.0",
     "protocol-buffers": "^3.1.4",
     "stable": "^0.1.5"

--- a/src/dag-service.js
+++ b/src/dag-service.js
@@ -1,6 +1,6 @@
 const DAGNode = require('./dag-node').DAGNode
 const Block = require('ipfs-blocks').Block
-const isIPFS = require('../node_modules/is-ipfs/src/index')
+const isIPFS = require('is-ipfs')
 const base58 = require('bs58')
 
 exports = module.exports = DAGService

--- a/src/dag-service.js
+++ b/src/dag-service.js
@@ -38,7 +38,7 @@ function DAGService (blockService) {
     }
 
     if (isPath) {
-      var ipfsKey = new Buffer(base58.decode(multihash.replace('/ipfs/', '')))
+      var ipfsKey = multihash.replace('/ipfs/', '')
       this.getWith(ipfsKey, callback)
     }
   }

--- a/src/dag-service.js
+++ b/src/dag-service.js
@@ -33,14 +33,16 @@ function DAGService (blockService) {
     }
 
     if (typeof multihash === 'string') {
-      if (!isIPFS.multihash(multihash) && !isIPFS.path(multihash)) {
+      var isMhash = isIPFS.multihash(multihash)
+      var isPath = isIPFS.path(multihash)
+      if (!isMhash && !isPath) {
         return callback(new Error('Invalid Key'))
       }
-      if (isIPFS.multihash(multihash)) {
+      if (isMhash) {
         var mhBuffer = new Buffer(base58.decode(multihash))
         this.getWith(mhBuffer, callback)
       }
-      if (isIPFS.path(multihash)) {
+      if (isPath) {
         var ipfsKey = new Buffer(base58.decode(multihash.replace('/ipfs/', '')))
         this.getWith(ipfsKey, callback)
       }

--- a/src/dag-service.js
+++ b/src/dag-service.js
@@ -26,13 +26,20 @@ function DAGService (blockService) {
 
   // get retrieves a DAGNode, using the Block Service
   this.get = function (multihash, callback) {
-    if (Buffer.isBuffer(multihash)) {
+    const isBuf = Buffer.isBuffer(multihash)
+    const isString = typeof multihash === 'string'
+
+    if (!isBuf && !isString) {
+      return callback(new Error('Invalid Key'))
+    }
+
+    if (isBuf) {
       var mhString = base58.encode(multihash)
       if (!isIPFS.multihash(mhString)) { return callback(new Error('Invalid Key')) }
       this.getWith(multihash, callback)
     }
 
-    if (typeof multihash === 'string') {
+    if (isString) {
       var isMhash = isIPFS.multihash(multihash)
       var isPath = isIPFS.path(multihash)
       if (!isMhash && !isPath) {

--- a/tests/merkle-dag-tests.js
+++ b/tests/merkle-dag-tests.js
@@ -154,7 +154,22 @@ module.exports = function (repo) {
       })
     })
 
-    it('get a mdag node', (done) => {
+    it('get a mdag node from base58 encoded string', (done) => {
+      const node = new DAGNode(new Buffer('more data data data'))
+      dagService.add(node, (err) => {
+        expect(err).to.not.exist
+        var mh = node.multihash()
+        var encodedMh = bs58.encode(mh)
+        dagService.get(encodedMh, (err, fetchedNode) => {
+          expect(err).to.not.exist
+          expect(node.data).to.deep.equal(fetchedNode.data)
+          expect(node.links).to.deep.equal(fetchedNode.links)
+          done()
+        })
+      })
+    })
+
+    it('get a mdag node from a multihash buffer', (done) => {
       const node = new DAGNode(new Buffer('more data data data'))
       dagService.add(node, (err) => {
         expect(err).to.not.exist
@@ -165,6 +180,41 @@ module.exports = function (repo) {
           expect(node.links).to.deep.equal(fetchedNode.links)
           done()
         })
+      })
+    })
+
+    it('get a mdag node from a /ipfs/ path', (done) => {
+      const node = new DAGNode(new Buffer('more data data data'))
+      dagService.add(node, (err) => {
+        expect(err).to.not.exist
+        var mh = node.multihash()
+        var encodedMh = bs58.encode(mh)
+        var ipfsPath = '/ipfs/' + encodedMh
+        dagService.get(ipfsPath, (err, fetchedNode) => {
+          expect(err).to.not.exist
+          expect(node.data).to.deep.equal(fetchedNode.data)
+          expect(node.links).to.deep.equal(fetchedNode.links)
+          done()
+        })
+      })
+    })
+
+    it('supply an improperly formatted string path', (done) => {
+      var mh = 'bad path'
+      var ipfsPath = '/ipfs/' + mh
+      dagService.get(ipfsPath, (err, fetchedNode) => {
+        var error = 'Error: Invalid Key'
+        expect(err.toString()).to.eql(error)
+        done()
+      })
+    })
+
+    it('supply improperly formatted multihash buffer', (done) => {
+      var mh = new Buffer('more data data data')
+      dagService.get(mh, (err, fetchedNode) => {
+        var error = 'Error: Invalid Key'
+        expect(err.toString()).to.eql(error)
+        done()
       })
     })
 

--- a/tests/merkle-dag-tests.js
+++ b/tests/merkle-dag-tests.js
@@ -155,47 +155,34 @@ module.exports = function (repo) {
     })
 
     it('get a mdag node from base58 encoded string', (done) => {
-      const node = new DAGNode(new Buffer('more data data data'))
-      dagService.add(node, (err) => {
+      var encodedMh = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
+      dagService.get(encodedMh, (err, fetchedNode) => {
         expect(err).to.not.exist
-        var mh = node.multihash()
-        var encodedMh = bs58.encode(mh)
-        dagService.get(encodedMh, (err, fetchedNode) => {
-          expect(err).to.not.exist
-          expect(node.data).to.deep.equal(fetchedNode.data)
-          expect(node.links).to.deep.equal(fetchedNode.links)
-          done()
-        })
+        expect(fetchedNode.data).to.deep.equal(new Buffer(bs58.decode('cL')))
+        // just picking the second link and comparing mhash buffer to expected
+        expect(fetchedNode.links[1].hash).to.deep.equal(new Buffer(bs58.decode('QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y')))
+        done()
       })
     })
 
     it('get a mdag node from a multihash buffer', (done) => {
-      const node = new DAGNode(new Buffer('more data data data'))
-      dagService.add(node, (err) => {
+      var mh = new Buffer(bs58.decode('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'))
+      dagService.get(mh, (err, fetchedNode) => {
         expect(err).to.not.exist
-        var mh = node.multihash()
-        dagService.get(mh, (err, fetchedNode) => {
-          expect(err).to.not.exist
-          expect(node.data).to.deep.equal(fetchedNode.data)
-          expect(node.links).to.deep.equal(fetchedNode.links)
-          done()
-        })
+        expect(fetchedNode.data).to.deep.equal(new Buffer(bs58.decode('cL')))
+        expect(fetchedNode.links[1].hash).to.deep.equal(new Buffer(bs58.decode('QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y')))
+        done()
       })
     })
 
     it('get a mdag node from a /ipfs/ path', (done) => {
-      const node = new DAGNode(new Buffer('more data data data'))
-      dagService.add(node, (err) => {
+      var encodedMh = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
+      var ipfsPath = '/ipfs/' + encodedMh
+      dagService.get(ipfsPath, (err, fetchedNode) => {
         expect(err).to.not.exist
-        var mh = node.multihash()
-        var encodedMh = bs58.encode(mh)
-        var ipfsPath = '/ipfs/' + encodedMh
-        dagService.get(ipfsPath, (err, fetchedNode) => {
-          expect(err).to.not.exist
-          expect(node.data).to.deep.equal(fetchedNode.data)
-          expect(node.links).to.deep.equal(fetchedNode.links)
-          done()
-        })
+        expect(fetchedNode.data).to.deep.equal(new Buffer(bs58.decode('cL')))
+        expect(fetchedNode.links[1].hash).to.deep.equal(new Buffer(bs58.decode('QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y')))
+        done()
       })
     })
 
@@ -204,7 +191,7 @@ module.exports = function (repo) {
       var ipfsPath = '/ipfs/' + mh
       dagService.get(ipfsPath, (err, fetchedNode) => {
         var error = 'Error: Invalid Key'
-        expect(err.toString()).to.eql(error)
+        expect(err.toString()).to.equal(error)
         done()
       })
     })
@@ -213,7 +200,7 @@ module.exports = function (repo) {
       var mh = new Buffer('more data data data')
       dagService.get(mh, (err, fetchedNode) => {
         var error = 'Error: Invalid Key'
-        expect(err.toString()).to.eql(error)
+        expect(err.toString()).to.equal(error)
         done()
       })
     })

--- a/tests/merkle-dag-tests.js
+++ b/tests/merkle-dag-tests.js
@@ -176,8 +176,7 @@ module.exports = function (repo) {
     })
 
     it('get a mdag node from a /ipfs/ path', (done) => {
-      var encodedMh = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
-      var ipfsPath = '/ipfs/' + encodedMh
+      var ipfsPath = '/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
       dagService.get(ipfsPath, (err, fetchedNode) => {
         expect(err).to.not.exist
         expect(fetchedNode.data).to.deep.equal(new Buffer(bs58.decode('cL')))
@@ -198,6 +197,15 @@ module.exports = function (repo) {
 
     it('supply improperly formatted multihash buffer', (done) => {
       var mh = new Buffer('more data data data')
+      dagService.get(mh, (err, fetchedNode) => {
+        var error = 'Error: Invalid Key'
+        expect(err.toString()).to.equal(error)
+        done()
+      })
+    })
+
+    it('supply something weird', (done) => {
+      var mh = 3
       dagService.get(mh, (err, fetchedNode) => {
         var error = 'Error: Invalid Key'
         expect(err.toString()).to.equal(error)


### PR DESCRIPTION
This adds is-ipfs tests for correct paths and multihashes with is-ipfs. 

@diasdavid had discussed adding buffer condition to is-ipfs. This checks the supplied path to the dag-service to see if it is a buffer first, if it is then it base58 encodes the buffer and then tests with is-ipfs. 

If the path supplied to dag-service is a string then it checks to see if it is a path or a correct multihash.
