### PR TITLE
Check explicitly for DAGLink instance.

### DIFF
--- a/src/dag-node.js
+++ b/src/dag-node.js
@@ -51,7 +51,7 @@ module.exports = class DAGNode {
     // ensure links are instances of DAGLink
     if (links) {
       links.forEach((l) => {
-        if (l.name && typeof l.toJSON === 'function') {
+        if (l instanceof DAGLink) {
           this.links.push(l)
         } else {
           this.links.push(

--- a/src/dag-node.js
+++ b/src/dag-node.js
@@ -51,7 +51,7 @@ module.exports = class DAGNode {
     // ensure links are instances of DAGLink
     if (links) {
       links.forEach((l) => {
-        if (l instanceof DAGLink) {
+        if (l.constructor && l.constructor.name === 'DAGLink') {
           this.links.push(l)
         } else {
           this.links.push(

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -213,5 +213,28 @@ module.exports = function (repo) {
         'DAGNode <QmU1Sq1B7RPQD2XcQNLB58qJUyJffVJqihcxmmN1STPMxf - data: "hello world", links: 0, size: 13>'
       )
     })
+
+    it('add two nameless links to a node', function (done) {
+      const l1 = {
+        Name: '',
+        Hash: 'QmbAmuwox51c91FmC2jEX5Ng4zS4HyVgpA5GNPBF5QsWMA',
+        Size: 57806
+      }
+      const l2 = {
+        Name: '',
+        Hash: 'QmP7SrR76KHK9A916RbHG1ufy2TzNABZgiE23PjZDMzZXy',
+        Size: 262158
+      }
+      const link1 = new DAGLink(l1.Name, l1.Size, new Buffer(bs58.decode(l1.Hash)))
+      const link2 = new DAGLink(l2.Name, l2.Size, new Buffer(bs58.decode(l2.Hash)))
+
+      function createNode () {
+        return new DAGNode(new Buffer('hiya'), [link1, link2])
+      }
+
+      expect(createNode).to.not.throw()
+
+      done()
+    })
   })
 }


### PR DESCRIPTION
Includes previously failing test, occurring when passing in a `DAGLink` instance with no name.
